### PR TITLE
Fix security vulnerabilities

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ readme = "README.md"
 [tool.poetry.dependencies]
 python = "^3.9"
 fake-useragent = "^1.5.1"
-aiohttp = "^3.10.10"
+aiohttp = "^3.11.12"
 bs4 = "^0.0.2"
 
 [build-system]


### PR DESCRIPTION
## Summary
- Bump aiohttp from ^3.10.10 to ^3.11.12 (fixes DoS, request smuggling, zip bomb, path leak, and other vulnerabilities)

**Note:** `poetry lock` needs to be run after merging to regenerate the lockfile.